### PR TITLE
fix ipxact2duh field parsing

### DIFF
--- a/lib/ml2on.js
+++ b/lib/ml2on.js
@@ -82,6 +82,8 @@ const objList = luter(`
   language
   usage
   componentInstantiationRef
+  readAction
+  modifiedWriteValue
 `);
 /*
 abstractionRef


### PR DESCRIPTION
add readAction and modifiedWriteValue params to objList

ipxact2duh has a strange behavior on readAction and modifiedWriteValue tags

example
```xml
<ipxact:field>
    <ipxact:name>Field</ipxact:name>
    <ipxact:bitOffset>0</ipxact:bitOffset>
    <ipxact:resets>
        <ipxact:reset>
            <ipxact:value>0</ipxact:value>
        </ipxact:reset>
    </ipxact:resets>
    <ipxact:bitWidth>1</ipxact:bitWidth>
    <ipxact:volatile>true</ipxact:volatile>
    <ipxact:access>read-write</ipxact:access>
    <ipxact:modifiedWriteValue>set</ipxact:modifiedWriteValue>
    <ipxact:readAction>clear</ipxact:readAction>
</ipxact:field>
```

becomes

```json5
fields: [
  {
    '0': 'ipxact:readAction',
    '1': {},
    '2': 'clear',
    name: 'Field',
    bitOffset: 0,
    resets: [
      {
        value: 0,
      },
    ],
    bitWidth: 1,
    volatile: true,
    access: 'read-write',
  },
],
```

looks like this fix will resolve this problem

```json5
fields: [
  {
    name: 'Field',
    bitOffset: 0,
    resets: [
      {
        value: 0,
      },
    ],
    bitWidth: 1,
    volatile: true,
    access: 'read-write',
    modifiedWriteValue: 'set',
    readAction: 'clear',
  },
],
```